### PR TITLE
Bug in interpretation of json from blockchain.info/unspent

### DIFF
--- a/js/tx.js
+++ b/js/tx.js
@@ -305,7 +305,7 @@ function tx_parseBCI(data, address) {
         var value = new BigInteger('' + o.value, 10);
         if (!(lilendHash in unspenttxs))
             unspenttxs[lilendHash] = {};
-        unspenttxs[lilendHash][i] = {amount: value, script: script};
+        unspenttxs[lilendHash][o.tx_output_n] = {amount: value, script: script};
         balance = balance.add(value);
     }
     return {balance:balance, unspenttxs:unspenttxs};


### PR DESCRIPTION
The index in the unspent_outs array doesn't correspond to the output index in the transaction as it does in blockexplorer's. The tx_output_n should be used instead.
