### PR TITLE
Added PBKDF2 (300000 iterations) hashing support in addition to SHA256

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
     <script src="js/tx.js"></script>
     <script src="js/bitcoinsig.js"></script>
     <script src="js/brainwallet.js"></script>
+    <script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/sha256.js"></script>
+    <script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/pbkdf2.js"></script>
+    <script src="http://crypto.stanford.edu/sjcl/sjcl.js"></script> <!-- figure out license for this for redistribution since this is BSD rather than the public domain license this is using -->
   </head>
   <body onclick="rng_seed_time();" onkeypress="rng_seed_time();">
     <header class="navbar navbar-inverse navbar-fixed-top">
@@ -77,6 +80,7 @@
                   <div class="input-group">
                     <input class="form-control" id="pass" type="text" />
                     <div class="input-group-btn">
+                      <button class="btn btn-default" id="secureHash" title="Choose 'Secure' to use PBKDF2 for a more secure hash" type="button">Use Secure</button>
                       <button class="btn btn-default" id="hidePassphrase" title="Show/Hide Passphrase" type="button">Hide</button>
                     </div>
                   </div>

--- a/index.html
+++ b/index.html
@@ -74,8 +74,11 @@
               <div class="form-group">
                 <label class="col-lg-2 control-label" for="pass">Passphrase</label>
                 <div class="col-lg-10 controls">
-                  <div class="input-append">
+                  <div class="input-group">
                     <input class="form-control" id="pass" type="text" />
+                    <div class="input-group-btn">
+                      <button class="btn btn-default" id="hidePassphrase" title="Show/Hide Passphrase" type="button">Hide</button>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -21,8 +21,6 @@
     <script src="js/tx.js"></script>
     <script src="js/bitcoinsig.js"></script>
     <script src="js/brainwallet.js"></script>
-    <script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/sha256.js"></script>
-    <script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/pbkdf2.js"></script>
     <script src="http://crypto.stanford.edu/sjcl/sjcl.js"></script> <!-- figure out license for this for redistribution since this is BSD rather than the public domain license this is using -->
   </head>
   <body onclick="rng_seed_time();" onkeypress="rng_seed_time();">

--- a/js/brainwallet.js
+++ b/js/brainwallet.js
@@ -309,11 +309,6 @@
         else { // 'pbkdf2'
             var passphrase = $('#pass').val();
 
-            //var salt = CryptoJS.SHA256('brainwallet'); // not ideal as we have a global shared salt but nothing we can do here since we don't have extra information. The user really needs to manually salt their password with custom information.
-            //var pbkdf2Hash = CryptoJS.PBKDF2(passphrase, salt, { keySize: 256/32, iterations: pbkdf2_iteration, hasher:CryptoJS.algo.SHA256 });
-            //var hashString = pbkdf2Hash.toString();
-            //$('#hash').val(hashString);
-
             var salt = sjcl.hash.sha256.hash('brainwallet'); // not ideal as we have a global shared salt but nothing we can do here since we don't have extra stored per-user info. The user really needs to manually salt their password with custom information.
             var pbkdf2Hash = sjcl.misc.pbkdf2(passphrase, salt, pbkdf2_iteration, 256);
             var hashString = sjcl.codec.hex.fromBits(pbkdf2Hash);

--- a/js/brainwallet.js
+++ b/js/brainwallet.js
@@ -136,6 +136,18 @@
         }
     }
 
+    function showHidePassphrase() {
+        var pass = $('#pass');
+        if (pass.attr('type') == 'password') {
+            pass.attr('type', 'text');
+            $('#hidePassphrase').html('Hide');
+        }
+        else {
+            pass.attr('type', 'password');
+            $('#hidePassphrase').html('Show');
+        }
+    }
+
     function genRandom() {
         $('#pass').val('');
         $('#hash').focus();
@@ -1184,6 +1196,7 @@
         onInput('#hash', onChangeHash);
         onInput('#sec', onChangePrivKey);
 
+        $('#hidePassphrase').click(showHidePassphrase);
         $('#genRandom').click(genRandom);
 
         $('#gen_from label input').on('change', update_gen_from );

--- a/js/brainwallet.js
+++ b/js/brainwallet.js
@@ -5,6 +5,8 @@
     var gen_eckey = null;
     var gen_pt = null;
     var gen_ps_reset = false;
+    var hash_method = 'sha256';
+    var pbkdf2_iteration = 100000;
     var TIMEOUT = 600;
     var timeout = null;
 
@@ -134,6 +136,27 @@
             group.removeClass('has-error');
             group.attr('title','');
         }
+    }
+
+    function toggleSecureHash() {
+        if (hash_method == 'sha256') {
+            hash_method = 'pbkdf2';
+            $('#from_pass').parent().attr('title', 'PBKDF2 (' + pbkdf2_iteration + ' iterations)');
+            $('#secureHash').html('Use Normal');
+        }
+        else {
+            hash_method = 'sha256';
+            $('#from_pass').parent().attr('title', 'Single SHA256');
+            $('#secureHash').html('Use Secure');
+        }
+
+        $('#pass').focus();
+        gen_from = 'pass';
+        $('#from_pass').click();
+        update_gen();
+
+        calc_hash();
+        generate();
     }
 
     function showHidePassphrase() {
@@ -279,14 +302,38 @@
 
 
     function calc_hash() {
-        var hash = Crypto.SHA256($('#pass').val(), { asBytes: true });
-        $('#hash').val(Crypto.util.bytesToHex(hash));
+        if (hash_method == 'sha256') {
+            var hash = Crypto.SHA256($('#pass').val(), { asBytes: true });
+            $('#hash').val(Crypto.util.bytesToHex(hash));
+        }
+        else { // 'pbkdf2'
+            var passphrase = $('#pass').val();
+
+            //var salt = CryptoJS.SHA256('brainwallet'); // not ideal as we have a global shared salt but nothing we can do here since we don't have extra information. The user really needs to manually salt their password with custom information.
+            //var pbkdf2Hash = CryptoJS.PBKDF2(passphrase, salt, { keySize: 256/32, iterations: pbkdf2_iteration, hasher:CryptoJS.algo.SHA256 });
+            //var hashString = pbkdf2Hash.toString();
+            //$('#hash').val(hashString);
+
+            var salt = sjcl.hash.sha256.hash('brainwallet'); // not ideal as we have a global shared salt but nothing we can do here since we don't have extra stored per-user info. The user really needs to manually salt their password with custom information.
+            var pbkdf2Hash = sjcl.misc.pbkdf2(passphrase, salt, pbkdf2_iteration, 256);
+            var hashString = sjcl.codec.hex.fromBits(pbkdf2Hash);
+            $('#hash').val(hashString);
+        }
     }
 
     function onChangePass() {
-        calc_hash();
-        clearTimeout(timeout);
-        timeout = setTimeout(generate, TIMEOUT);
+        if (hash_method == 'sha256') {
+            calc_hash();
+            clearTimeout(timeout);
+            timeout = setTimeout(generate, TIMEOUT);
+        }
+        else { // hash is too slow, just do it before we generate
+            clearTimeout(timeout);
+            timeout = setTimeout(function() {
+                calc_hash();
+                generate();
+            }, TIMEOUT);
+        }
     }
 
     function onChangeHash() {
@@ -1196,6 +1243,7 @@
         onInput('#hash', onChangeHash);
         onInput('#sec', onChangePrivKey);
 
+        $('#secureHash').click(toggleSecureHash);
         $('#hidePassphrase').click(showHidePassphrase);
         $('#genRandom').click(genRandom);
 


### PR DESCRIPTION
Most passphrases don't tend to be very secure or high entropy so I added PBKDF2 support to make the hashes less prone to attacks since they are more expensive to guess. By default it's still using SHA256 but you can now select "Use Secure" to toggle the secure hash mode which uses PBKDF2 with 300000 iterations. Right now using Stanford's sjcl library since that's faster than CryptoJS. Still need to download the JS file and cache it in the repository like the other JS files instead of direct reference to external server.

Also added a button to hide the passphrase although the private keys are still visible. Maybe when we're in hiding mode should hide all private keys?
