### PR TITLE
Trim the paper backup area for electrum chain

### DIFF
--- a/js/brainwallet.js
+++ b/js/brainwallet.js
@@ -755,6 +755,7 @@
         }
 
         if (chType == 'electrum') {
+            str = str.trim();
             if (issubset(mn_words, str, 12))  {
                 var seed = mn_decode(str);
                 $('#chRoot').val(seed);


### PR DESCRIPTION
If one leave extra trailing space at the end of the "Paper Backup" area in the "Chains" tab in electrum mode, the computed seed is wrong and thus the rest as well. This commit fix this issue.
